### PR TITLE
Fix: Correct ParserError in SecurityIncidentResponder._ExecuteAction

### DIFF
--- a/src/automation/Security_Incident_Responder.ps1
+++ b/src/automation/Security_Incident_Responder.ps1
@@ -192,7 +192,7 @@ class SecurityIncidentResponder {
 
     hidden [object] _ExecuteAction([object]$action, [object]$context) {
         Write-Host "SecurityIncidentResponder._ExecuteAction() (Corrected for RunPSScript & Logging) called for action type: $($action.actionType)"
-        Write-Host ""Context received by _ExecuteAction (IncidentId: '', Keys: ' )"" # More detailed log
+        Write-Host "Context received by _ExecuteAction (IncidentId: '', Keys: ' )" # More detailed log
         $actionType = $action.actionType
         $parameters = $action.parameters
         $result = @{ Status = "Failed"; Output = "Action type '$actionType' not implemented or failed."; StartTime = (Get-Date)}


### PR DESCRIPTION
Removes an extraneous double quote in a Write-Host statement within the _ExecuteAction method in `src/automation/Security_Incident_Responder.ps1`.

This error was preventing the `SecurityIncidentResponder` class from being loaded and blocking integration tests. The fix allows the class to be parsed and instantiated successfully.